### PR TITLE
Add ternary operator support

### DIFF
--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -324,7 +324,7 @@ const printTact: Printer<SyntaxNode>['print'] = (path, _options, print) => {
         ' {',
         indent([
           ...(node.namedChild(0)
-          && doesNodesInSameRow(node.namedChild(0)!, node))
+            && doesNodesInSameRow(node.namedChild(0)!, node))
             ? []
             : [hardline],
           path.map(print, 'namedChildren'),
@@ -436,6 +436,14 @@ const printTact: Printer<SyntaxNode>['print'] = (path, _options, print) => {
     case 'binary_expression':
       // maybe not to use node.text for method_call_experssion and binary_expression
       return node.text
+    case 'ternary_expression':
+      return group([
+        path.call(print, 'namedChildren', 0),
+        ' ? ',
+        path.call(print, 'namedChildren', 1),
+        ' : ',
+        path.call(print, 'namedChildren', 2),
+      ])
     case 'identifier':
     case 'type_identifier':
     case 'self':

--- a/test/syntax/__snapshots__/ternary.tact.snap
+++ b/test/syntax/__snapshots__/ternary.tact.snap
@@ -1,0 +1,4 @@
+fun test_ternary() {
+    let age: Int = 26;
+    let bevarage: String = age >= 21 ? "Beer" : "Juice";
+}

--- a/test/syntax/ternary.tact
+++ b/test/syntax/ternary.tact
@@ -1,0 +1,4 @@
+fun test_ternary() {
+  let age: Int = 26;
+  let bevarage: String = age >= 21 ? "Beer" : "Juice";
+}


### PR DESCRIPTION
**PR summary**:

Without this changes this plugin format ternary operator to empty space. It breaking code.

P.S.
I ran this plugin on my tact code and it created a lot of errors. if you don't mind i could open issues for errors. Do you have plans on support and improve this repo?